### PR TITLE
Switched = & <

### DIFF
--- a/MasterFramework 33/Drawing/Decorations/Stroke.lua
+++ b/MasterFramework 33/Drawing/Decorations/Stroke.lua
@@ -28,7 +28,7 @@ function framework:Stroke(width, color, inside)
 
 	function stroke:Draw(rect, x, y, width, height)
 		local strokeWidth = self.width()
-		if strokeWidth =< 0 then
+		if strokeWidth <= 0 then
 			return 
 		end
 


### PR DESCRIPTION
Getting syntax errors the way it was, switching them to <= resolved this.